### PR TITLE
Issue #103: Refactor user update

### DIFF
--- a/data/postgres/user_driver.go
+++ b/data/postgres/user_driver.go
@@ -27,10 +27,13 @@ type (
 const (
 	UserListQuery   = `SELECT id, login, public_key, player_id, created, updated FROM users`
 	UserGetQuery    = `SELECT id, login, public_key, player_id, created, updated FROM users WHERE id = $1`
-	UserCreateQuery = `INSERT INTO users (login, public_key, player_id) ` +
-		`VALUES ($1, $2, $3) ` +
+	UserCreateQuery = `INSERT INTO users (login, public_key) ` +
+		`VALUES ($1, $2) ` +
 		`RETURNING id, login, public_key, player_id, created, updated`
-	UserUpdateQuery = `UPDATE users SET login = $2, public_key = $3, player_id = $4 ` +
+	UserUpdateQuery = `UPDATE users SET login = $2, public_key = $3 ` +
+		`WHERE id = $1 ` +
+		`RETURNING id, login, public_key, player_id, created, updated`
+	AssociatePlayerQuery = `UPDATE users SET player_id = $2 ` +
 		`WHERE id = $1 ` +
 		`RETURNING id, login, public_key, player_id, created, updated`
 	UserRemoveQuery = `DELETE FROM users WHERE id = $1`
@@ -50,6 +53,9 @@ func (UserDriver) CreateQuery() string { return UserCreateQuery }
 
 // UpdateQuery returns the Update query string.
 func (UserDriver) UpdateQuery() string { return UserUpdateQuery }
+
+// AssociatePlayerQuery returns the AssociatePlayer query string.
+func (UserDriver) AssociatePlayerQuery() string { return AssociatePlayerQuery }
 
 // RemoveQuery returns the Remove query string.
 func (UserDriver) RemoveQuery() string { return UserRemoveQuery }

--- a/openapi/users-openapi.yaml
+++ b/openapi/users-openapi.yaml
@@ -111,7 +111,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
-          description: The user associated with the userID does not exist.
+          description: The user associated with the ID does not exist.
           content:
             application/json:
               schema:
@@ -154,7 +154,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "404":
-          description: The user associated with the userID does not exist.
+          description: The user associated with the ID does not exist.
           content:
             application/json:
               schema:
@@ -165,6 +165,50 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+
+    patch:
+      summary: Associates a player with a user.
+      description: On successful completion, the playerID is associated with the user.
+      operationId: AssociatePlayer
+      parameters:
+        - name: id
+          description: The ID of the user.
+          required: true
+          in: path
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssociatePlayerRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsersResponse"
+        "400":
+          description: A bad request was sent.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: The user associated with the ID does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: An internal server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
     delete:
       summary: Remove removes a user.
       description: On successful completion, the user is removed.
@@ -251,17 +295,11 @@ components:
       required:
         - login
         - publicKey
-        - playerID
       properties:
         login:
           type: string
-          x-order: 1
         publicKey:
           type: string
-          x-order: 2
-        playerID:
-          type: string
-          x-order: 3
 
     UserUpdateRequest:
       type: object
@@ -269,17 +307,20 @@ components:
       required:
         - login
         - publicKey
-        - playerID
       properties:
         login:
           type: string
-          x-order: 1
         publicKey:
           type: string
-          x-order: 2
+
+    AssociatePlayerRequest:
+      type: object
+      description: AssociatePlayerRequest is used to associate a player to the user.
+      required:
+        - playerID
+      properties:
         playerID:
           type: string
-          x-order: 3
 
     ErrorResponse:
       type: object

--- a/user/user.go
+++ b/user/user.go
@@ -72,10 +72,14 @@ type (
 		Change
 	}
 
-	// UserChange holds information to change an user.
+	// Change holds information to change an user.
 	Change struct {
 		Login     string
 		PublicKey []byte
-		PlayerID  asset.PlayerID
+	}
+
+	// AssociatePlayer holds information to assocuate a player to a user.
+	AssociatePlayer struct {
+		PlayerID asset.PlayerID
 	}
 )


### PR DESCRIPTION
### Issue
Fixes #103: Refactor user update

### What
- adds a new endpoint, /v1/user/{id}, patch, which associated a player with the user
- modifies the users openapi defn for the new endpoint
- creates the new endpoint with UserService.AssociatePlayer method
- creates the new UserStore.AssociatePlayer method
- updates all unit tests
- adds new unit tests for the new methods
- refactored the dockertests to include associating the player

### How to test
- make test