### PR TITLE
Issue #150: Introduce telnet_adapter server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ integration_test: integration_test_up assets_integration_test users_integration_
 
 # ____ image artifacts  __________________________________________________
 
-.PHONY: images assets users migrate mkcert curl
+.PHONY: images assets users tad migrate mkcert curl telnet tools
 
 export buildargs :=
 
@@ -174,7 +174,7 @@ dev-images: buildargs := -cover
 dev-images:
 	make -C dockerfiles all
 
-assets users migrate mkcert curl:
+assets users tad migrate mkcert curl telnet tools:
 	make -C dockerfiles $@
 
 # ____ clean artifacts _______________________________________________________

--- a/bin/dev
+++ b/bin/dev
@@ -17,6 +17,7 @@ declare -ar infrastructure=(
 declare -ar tls_servers=(
 	"assets"
 	"users"
+  "tad"
 	"influxdb"
 	"postgres"
 )
@@ -24,6 +25,7 @@ declare -ar tls_servers=(
 declare -ar tls_clients=(
 	"assets"
 	"users"
+  "tad"
 	"migrate"
 	"psql"
 )
@@ -37,6 +39,7 @@ declare -ar networks=(
 declare -ar services=(
 	"assets"
 	"users"
+  "tad"
 )
 
 declare -Ar influxdb_config=(

--- a/cmd/assets/main.go
+++ b/cmd/assets/main.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 arcadium.dev <info@arcadium.dev>
+// Copyright 2021-2026 arcadium.dev <info@arcadium.dev>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,12 +42,6 @@ var (
 )
 
 type (
-	// Server defines the expected behavior of a server.
-	Server interface {
-		Serve() error
-		Ctx() context.Context
-	}
-
 	Config struct {
 		Database    string `required:"true"`
 		PostgresDsn string `split_words:"true"`

--- a/cmd/tad/main.go
+++ b/cmd/tad/main.go
@@ -1,0 +1,103 @@
+// Copyright 2026 arcadium.dev <info@arcadium.dev>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	l "log"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"arcadium.dev/core/http/middleware"
+	httpserver "arcadium.dev/core/http/server"
+	"arcadium.dev/core/http/services"
+	"arcadium.dev/core/mpserver"
+	"arcadium.dev/core/telnet"
+
+	"arcadium.dev/arcade/tad"
+)
+
+var (
+	Version string
+	Branch  string
+	Commit  string
+	Date    string
+)
+
+func Main() error {
+	var err error
+
+	// Create the multiprotocol server.
+	mpCfg, err := mpserver.NewConfig("tad")
+	if err != nil {
+		return fmt.Errorf("failed to load mpserver configuration: %w", err)
+	}
+
+	s, err := mpserver.New(Version, Branch, Commit, Date, mpCfg.ToOptions()...)
+	if err != nil {
+		return fmt.Errorf("failed to create new mpserver: %w", err)
+	}
+	logger := s.Logger()
+
+	// Create the telnet adapter server.
+	telnetCfg, err := telnet.NewServerConfig("tad_telnet")
+	if err != nil {
+		return fmt.Errorf("failed to load http server configuration: %w", err)
+	}
+
+	telnetServer := telnet.NewServer(append(telnetCfg.ToOptions(), telnet.WithServerLogger(logger))...)
+	telnetServer.Register(&tad.Service{})
+	s.Register(telnetServer)
+
+	// Create the http server, for the health and metrics services.
+	httpCfg, err := httpserver.NewConfig("tad_http")
+	if err != nil {
+		return fmt.Errorf("failed to load http server configuration: %w", err)
+	}
+
+	httpServer, err := httpserver.New(append(httpCfg.ToOptions(), httpserver.WithLogger(logger))...)
+	if err != nil {
+		return fmt.Errorf("failed to create new http server: %w", err)
+	}
+
+	svcs := []httpserver.Service{
+		services.Health{Start: time.Now(), Info: s.Info()},
+		services.Metrics{},
+	}
+
+	mw := []mux.MiddlewareFunc{
+		middleware.Recover{Logger: logger}.Panics,
+		middleware.Logging{Logger: logger}.Requests,
+		middleware.Metrics,
+	}
+	httpServer.Middleware(mw...)
+
+	httpServer.Register(svcs...)
+	s.Register(httpServer)
+
+	// Let's go...
+	if err := s.Serve(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if err := Main(); err != nil {
+		l.Fatal(err)
+	}
+}

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -1,4 +1,4 @@
-// Copyright 2024 arcadium.dev <info@arcadium.dev>
+// Copyright 2024-2026 arcadium.dev <info@arcadium.dev>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,12 +42,6 @@ var (
 )
 
 type (
-	// Server defines the expected behavior of a server.
-	Server interface {
-		Serve() error
-		Ctx() context.Context
-	}
-
 	Config struct {
 		Database    string `required:"true"`
 		PostgresDsn string `split_words:"true"`

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,10 +31,33 @@ services:
       - database_network
       - observability_network
 
+  tad:
+    image: tad:latest
+    container_name: tad
+    env_file:
+      - env/arcade
+    ports:
+      - 4201:23
+      - 4230:443
+    volumes:
+      - certificates_volume:/etc/certs
+      - ./tad/test/coverage:/arcadium/coverage
+    networks:
+      - arcadium_network
+      - observability_network
+
   # arcadium clients
   #------------------------------------------------------------------------
   curl:
     image: curl:latest
+    working_dir: /etc
+    volumes:
+      - certificates_volume:/etc/certs
+    networks:
+      - arcadium_network
+
+  telnet:
+    image: telnet:latest
     working_dir: /etc
     volumes:
       - certificates_volume:/etc/certs

--- a/dockerfiles/Dockerfile.assets
+++ b/dockerfiles/Dockerfile.assets
@@ -55,7 +55,7 @@ RUN apk update && \
 COPY --from=builder --chown=arcadium:arcadium /src/dist/assets /arcadium/assets
 
 USER  arcadium:arcadium
-EXPOSE 4202
+EXPOSE 443
 VOLUME ["/etc/certs"]
 WORKDIR /arcadium
 ENTRYPOINT ["/arcadium/assets"]

--- a/dockerfiles/Dockerfile.tad
+++ b/dockerfiles/Dockerfile.tad
@@ -14,12 +14,8 @@ RUN apk update && apk add --no-cache git libcap openssh \
     && git config --global url."git@github.com:".insteadOf "https://github.com/" \
     && mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-# Create a separate layer for the go dependencies to facilitate faster builds.
-COPY go.mod go.sum ./
-RUN --mount=type=ssh go mod download && go mod verify
-
-# Create a layer for the build.
 COPY . ./
+RUN --mount=type=ssh go mod download && go mod verify
 
 ARG version
 ARG branch
@@ -34,8 +30,8 @@ RUN GOOS="linux" GOARCH="${arch:-amd64}" CGO_ENAGLED=0 \
       -X 'main.Branch=${branch}' \
       -X 'main.Commit=${commit}' \
       -X 'main.Date=${build_date}'" \
-      -o ./dist/users ./cmd/users \
-    && setcap 'cap_net_bind_service=+ep' ./dist/users
+      -o ./dist/tad ./cmd/tad \
+    && setcap 'cap_net_bind_service=+ep' ./dist/tad
 
 
 # Users image.
@@ -52,10 +48,11 @@ RUN apk update && \
     --uid "10001" \
     arcadium
 
-COPY --from=builder --chown=arcadium:arcadium /src/dist/users /arcadium/users
+COPY --from=builder --chown=arcadium:arcadium /src/dist/tad /arcadium/tad
 
 USER  arcadium:arcadium
+EXPOSE 23
 EXPOSE 443
 VOLUME ["/etc/certs"]
 WORKDIR /arcadium
-ENTRYPOINT ["/arcadium/users"]
+ENTRYPOINT ["/arcadium/tad"]

--- a/dockerfiles/Dockerfile.telnet
+++ b/dockerfiles/Dockerfile.telnet
@@ -1,0 +1,16 @@
+FROM alpine:latest
+
+RUN apk update && \
+    apk add --no-cache ca-certificates tzdata bash busybox-extras && update-ca-certificates && \
+    adduser \
+      --disabled-password \
+      --gecos "" \
+      --home "/nonexistent" \
+      --shell "/sbin/nologin" \
+      --no-create-home \
+      --uid "10001" \
+      arcadium
+
+USER arcadium:arcadium
+VOLUME /etc/certs
+ENTRYPOINT  ["/usr/bin/telnet"]

--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -27,7 +27,7 @@ all: images tools
 
 .PHONY: images assets users migrate
 
-images: assets users migrate
+images: assets users tad migrate
 
 assets: Dockerfile.assets
 	DOCKER_BUILDKIT=1 docker build \
@@ -59,6 +59,21 @@ users: Dockerfile.users
 		--tag users:latest \
 		..
 
+tad: Dockerfile.tad
+	DOCKER_BUILDKIT=1 docker build \
+		--file Dockerfile.tad \
+		--ssh default \
+		--build-arg go_version=$(go_version) \
+		--build-arg arc=$(arch) \
+		--build-arg version=$(version) \
+		--build-arg branch=$(branch) \
+		--build-arg commit=$(commit) \
+		--build-arg build_date=$(date) \
+		--build-arg buildargs=$(buildargs) \
+		--rm --force-rm \
+		--tag tad:latest \
+		..
+
 migrate: Dockerfile.migrate
 	DOCKER_BUILDKIT=1 docker build \
     --file Dockerfile.migrate \
@@ -69,9 +84,9 @@ migrate: Dockerfile.migrate
 
 # ____ tools _________________________________________________________________
 
-.PHONY: tools mkcert curl
+.PHONY: tools mkcert curl telnet
 
-tools: mkcert curl
+tools: mkcert curl telnet
 
 mkcert: Dockerfile.mkcert
 	docker build \
@@ -87,4 +102,11 @@ curl: Dockerfile.curl
 		--file Dockerfile.curl \
 		--rm --force-rm \
 		--tag curl:latest \
+		.
+
+telnet: Dockerfile.telnet
+	docker build \
+		--file Dockerfile.telnet \
+		--rm --force-rm \
+		--tag telnet:latest \
 		.

--- a/dockerfiles/mkcert.sh
+++ b/dockerfiles/mkcert.sh
@@ -13,6 +13,10 @@ chown -R arcadium:arcadium \
 	/etc/certs/users.pem \
 	/etc/certs/users_client.pem \
 	/etc/certs/users_client_key.pem \
+	/etc/certs/tad_key.pem \
+	/etc/certs/tad.pem \
+	/etc/certs/tad_client.pem \
+	/etc/certs/tad_client_key.pem \
 	/etc/certs/rootCA.pem &>/dev/null
 chmod 0644 /etc/certs/influx* || true
 

--- a/env/arcade
+++ b/env/arcade
@@ -59,3 +59,21 @@ USERS_HTTP_TLS_CERT="/etc/certs/users.pem"
 
 USERS_DATABASE="postgres"
 USERS_POSTGRES_DSN="postgres://arcadium:arcadium@postgres:5432/arcade?sslmode=verify-full&sslcert=/etc/certs/users_client.pem&sslkey=/etc/certs/users_client_key.pem&sslrootcert=/etc/certs/rootCA.pem"
+
+#___ tad _________________________________________________________________
+
+# LOG_LEVEL defines the level of logging.
+TAD_LOG_LEVEL="info"
+
+# SERVER_ADDR defines the address the arcade API service will listen to.
+# This is required.
+TAD_TELNET_SERVER_ADDR=":23"
+
+# SERVER_ADDR defines the address the arcade API service will listen to.
+# This is required.
+TAD_HTTP_SERVER_ADDR=":443"
+
+# TLS_CERT and TLS_KEY define the file path where the certificates used to
+# serve https traffic are stored. These are optional.
+TAD_HTTP_TLS_KEY="/etc/certs/tad_key.pem"
+TAD_HTTP_TLS_CERT="/etc/certs/tad.pem"

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,10 @@ module arcadium.dev/arcade
 
 go 1.26.4
 
+// replace arcadium.dev/core => ./core
+
 require (
-	arcadium.dev/core v0.2.16
+	arcadium.dev/core v0.2.19
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-cmp v0.7.0
@@ -39,6 +41,7 @@ require (
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/getkin/kin-openapi v0.135.0 // indirect
+	github.com/globalcyberalliance/telnet-go v0.0.0-20250807185007-4f349961b7ed // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.22.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-arcadium.dev/core v0.2.16 h1:fu68wyBbFCPb8Xmfbk7QBnwuUbebfPXmc9BHsCx2PDU=
-arcadium.dev/core v0.2.16/go.mod h1:BovjLSrIF+ORDCX0eEWt1cXH0wtc/75t2mPybJnTtdU=
+arcadium.dev/core v0.2.19 h1:S1qFNwQ0SdL7hwTxgsVvNKp9AKt/OSLutVjFtFgceX0=
+arcadium.dev/core v0.2.19/go.mod h1:BovjLSrIF+ORDCX0eEWt1cXH0wtc/75t2mPybJnTtdU=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
@@ -59,6 +59,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getkin/kin-openapi v0.135.0 h1:751SjYfbiwqukYuVjwYEIKNfrSwS5YpA7DZnKSwQgtg=
 github.com/getkin/kin-openapi v0.135.0/go.mod h1:6dd5FJl6RdX4usBtFBaQhk9q62Yb2J0Mk5IhUO/QqFI=
+github.com/globalcyberalliance/telnet-go v0.0.0-20250807185007-4f349961b7ed h1:dKNkb1fQ7mQ0oF1YMtmOjaOuqv1AyqU/cvlT0CuXfVs=
+github.com/globalcyberalliance/telnet-go v0.0.0-20250807185007-4f349961b7ed/go.mod h1:41nB/znwz3qzhRwqc6ywxLzX8aIUmeuMsR5QF67IfQE=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/tad/service.go
+++ b/tad/service.go
@@ -1,0 +1,59 @@
+//  Copyright 2026 arcadium.dev <info@arcadium.dev>
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package tad // import "arcadium.dev/arcade/tad"
+
+import (
+	"context"
+
+	"arcadium.dev/core/telnet"
+)
+
+type (
+	Service struct {
+	}
+)
+
+// Name returns the name of this service.
+func (s Service) Name() string {
+	return "telnet_adapter"
+}
+
+func (s *Service) ServeTELNET(session *telnet.Session) {
+	if err := session.WriteLine("Welcome!\n"); err != nil {
+		return
+	}
+
+	for {
+		line, err := session.ReadLine()
+		if err != nil {
+			return
+		}
+
+		if len(line) == 0 {
+			if err = session.WriteLine("Goodbye!\n"); err != nil {
+				return
+			}
+			return
+		}
+
+		if err = session.WriteLine("You wrote: " + line + "\n"); err != nil {
+			return
+		}
+	}
+}
+
+func (s *Service) Shutdown(ctx context.Context) {
+	// TODO
+}

--- a/tad/service_test.go
+++ b/tad/service_test.go
@@ -1,0 +1,1 @@
+package tad_test

--- a/user/server/server_test.go
+++ b/user/server/server_test.go
@@ -32,7 +32,7 @@ func assertRespError(t *testing.T, w *httptest.ResponseRecorder, status int, err
 func randString(size int) string {
 	s := "abcdefghijklmnopqrstuvwxyz "
 	b := make([]byte, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		b[i] = s[rand.Intn(len(s))]
 	}
 	return string(b)


### PR DESCRIPTION
### Issue
Fixes #150: Introduce telnet_adapter (tad) service

### What
- adds a new tad server in cmd/tad
- adds new tad container in dockerfile
- adds tad server to bin/dev
- add tad env config to env/arcade
- adds new telnet utility container to dockerfiles
- creates a placeholder telnet adapter service in tad/service.go

### How to test
- unit test runs successfully
- integration tests run successfully
- manually test new tad server